### PR TITLE
Modify PrefsUtils to use LiveData for storing Hook State

### DIFF
--- a/app/src/main/java/com/keshav/capturesposed/utils/PrefsUtils.kt
+++ b/app/src/main/java/com/keshav/capturesposed/utils/PrefsUtils.kt
@@ -1,13 +1,14 @@
 package com.keshav.capturesposed.utils
 
 import android.content.SharedPreferences
+import androidx.lifecycle.MutableLiveData
 import com.keshav.capturesposed.BuildConfig
 import io.github.libxposed.service.XposedService
 import io.github.libxposed.service.XposedServiceHelper
 
 object PrefsUtils {
     private var prefs: SharedPreferences? = null
-    private var hookActive: Boolean? = null
+    private var hookActive: MutableLiveData<Boolean> = MutableLiveData<Boolean>(null)
 
     fun loadPrefs() {
         XposedServiceHelper.registerListener(object : XposedServiceHelper.OnServiceListener {
@@ -25,18 +26,22 @@ object PrefsUtils {
             return false
         }
 
-        if (hookActive == null) {
-            hookActive = prefs!!.getBoolean("hookActive", true)
+        if (hookActive.value == null) {
+            hookActive.value = prefs!!.getBoolean("hookActive", true)
         }
-        return hookActive as Boolean
+        return hookActive.value as Boolean
     }
 
     fun toggleHookState() {
         if (XposedChecker.isEnabled()) {
-            hookActive = !isHookOn()
+            hookActive.value = !isHookOn()
             val prefEdit = prefs!!.edit()
-            prefEdit.putBoolean("hookActive", hookActive!!)
+            prefEdit.putBoolean("hookActive", hookActive.value!!)
             prefEdit.apply()
         }
+    }
+
+    fun getHookActiveAsLiveData(): MutableLiveData<Boolean> {
+        return hookActive
     }
 }


### PR DESCRIPTION
This PR modifies `PrefUtils` to use LiveData for storing the hook state.

Additionally, a function `getHookActiveAsLiveData()` has been added. This function is currently unused, however, it will be needed later for setting up the listener for updating the in-app toggle switch reflecting the hook state.

This PR does not introduce any user-facing changes to the app.