### PR TITLE
Modify Quick Settings Tile to use Disabled State when Module is Disabled

### DIFF
--- a/app/src/main/java/com/keshav/capturesposed/QuickTile.kt
+++ b/app/src/main/java/com/keshav/capturesposed/QuickTile.kt
@@ -3,6 +3,7 @@ package com.keshav.capturesposed
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
 import com.keshav.capturesposed.utils.PrefsUtils
+import com.keshav.capturesposed.utils.XposedChecker
 
 class QuickTile: TileService() {
     override fun onStartListening() {
@@ -18,10 +19,15 @@ class QuickTile: TileService() {
     }
 
     private fun setButtonState() {
-        if (PrefsUtils.isHookOn())
-            qsTile.state = Tile.STATE_ACTIVE
-        else
-            qsTile.state = Tile.STATE_INACTIVE
+        if (XposedChecker.isEnabled()) {
+            if (PrefsUtils.isHookOn())
+                qsTile.state = Tile.STATE_ACTIVE
+            else
+                qsTile.state = Tile.STATE_INACTIVE
+        }
+        else {
+            qsTile.state = Tile.STATE_UNAVAILABLE
+        }
         qsTile.updateTile()
     }
 }


### PR DESCRIPTION
This PR modifies the Quick Settings Tile to use the disabled state when the module is disabled.

When the module is installed but not enabled, the tile will now look like this:

![Screenshot_20240516-232553_Trebuchet](https://github.com/99keshav99/CaptureSposed/assets/7663225/9fd00d2e-50df-404a-857e-6d425b2206e2)

After the module has been enabled and the device has been rebooted, the tile will become useable:

![Screenshot_20240516-232719_Trebuchet](https://github.com/99keshav99/CaptureSposed/assets/7663225/dcc28087-8918-4915-b2af-d7c15831109a)