### PR TITLE
Modified in-app Toggle Switch to be Unusable when the Module is Disabled

### DIFF
--- a/app/src/main/java/com/keshav/capturesposed/MainActivity.kt
+++ b/app/src/main/java/com/keshav/capturesposed/MainActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.keshav.capturesposed.ui.theme.APPTheme
 import com.keshav.capturesposed.utils.PrefsUtils
+import com.keshav.capturesposed.utils.XposedChecker
 
 class MainActivity : ComponentActivity() {
 
@@ -79,6 +80,7 @@ class MainActivity : ComponentActivity() {
                     color = MaterialTheme.colorScheme.primary
                 )
                 Switch(
+                    enabled = XposedChecker.isEnabled(),
                     checked = isSwitchOn.value,
                     onCheckedChange = {
                         PrefsUtils.toggleHookState()


### PR DESCRIPTION
This PR modifies the in-app toggle switch to be unusable when the module is disabled. Attempting to toggle it when the module is disabled will result in no action and a slight difference in the appearance of the toggle.

When the module is disabled:
![Screenshot_20240518-013828](https://github.com/99keshav99/CaptureSposed/assets/7663225/0b5915ff-0293-4021-b9cc-2b86a4473a25)

When the module is enabled, hook is on:
![Screenshot_20240518-013711](https://github.com/99keshav99/CaptureSposed/assets/7663225/ee9d3fd1-9b7a-401b-baf1-ffca959b8ccc)

When the module is enabled, hook is off:
![Screenshot_20240518-013709](https://github.com/99keshav99/CaptureSposed/assets/7663225/5c39cee3-e7db-43a1-b87e-e14583a3b8fb)
