### PR TITLE
37 counter resets to 0 when system theme is switched

### DIFF
--- a/app/src/main/java/com/keshav/capturesposed/MainActivity.kt
+++ b/app/src/main/java/com/keshav/capturesposed/MainActivity.kt
@@ -35,6 +35,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         setTheme(R.style.Theme_APP)
         super.onCreate(savedInstanceState)
+        counter.intValue = savedInstanceState?.getInt("counter") ?: 0
         PrefsUtils.loadPrefs()
         isSwitchOn = mutableStateOf(PrefsUtils.isHookOn())
         PrefsUtils.getHookActiveAsLiveData().observe(this) { isActive ->
@@ -61,6 +62,11 @@ class MainActivity : ComponentActivity() {
     override fun onStart() {
         super.onStart()
         registerScreenCaptureCallback(mainExecutor, screenCaptureCallback)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putInt("counter", counter.intValue)
     }
 
     override fun onStop() {


### PR DESCRIPTION
This PR addresses an issue where the `counter.intValue` was being reset to `0` every time the system theme was changed from light to dark or vice versa.

To fix this issue, we have used the `savedInstanceState` bundle to persist the value of `counter` across configuration changes like a theme switch. This bundle is used to save and restore the transient state of an activity when it may be killed and later recreated.

Files changed:
- `app/src/main/java/com/keshav/capturesposed/MainActivity.kt`