### PR TITLE
Add Logic to Mark Tile Reveal as Done

### DIFF
--- a/app/src/main/java/com/keshav/capturesposed/QuickTile.kt
+++ b/app/src/main/java/com/keshav/capturesposed/QuickTile.kt
@@ -8,6 +8,7 @@ class QuickTile: TileService() {
     override fun onStartListening() {
         super.onStartListening()
         PrefsUtils.loadPrefs()
+        PrefsUtils.markTileRevealAsDone()
         setButtonState()
     }
 

--- a/app/src/main/java/com/keshav/capturesposed/utils/PrefsUtils.kt
+++ b/app/src/main/java/com/keshav/capturesposed/utils/PrefsUtils.kt
@@ -39,4 +39,12 @@ object PrefsUtils {
             prefEdit.apply()
         }
     }
+
+    fun markTileRevealAsDone() {
+        if (XposedChecker.isEnabled()) {
+            val prefEdit = prefs!!.edit()
+            prefEdit.putBoolean("tileRevealDone", true)
+            prefEdit.apply()
+        }
+    }
 }


### PR DESCRIPTION
This PR adds logic to prevent the System UI hook from applying on the next device boot after the tile reveal animation has been played.