### PR TITLE
Update MainActivity Display Switch Module is Enabled

### DIFF
--- a/app/src/main/java/com/keshav/capturesposed/MainActivity.kt
+++ b/app/src/main/java/com/keshav/capturesposed/MainActivity.kt
@@ -83,6 +83,20 @@ class MainActivity : ComponentActivity() {
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            SwitchOrText(isSwitchOn)
+            Text(
+                text = "Counter: $counter",
+                fontSize = 40.sp,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(50.dp),
+                color = MaterialTheme.colorScheme.secondary
+            )
+        }
+    }
+
+    @Composable
+    fun SwitchOrText(isSwitchOn: MutableState<Boolean>) {
+        if (XposedChecker.isEnabled()) {
             Row(
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -92,8 +106,8 @@ class MainActivity : ComponentActivity() {
                     textAlign = TextAlign.Center,
                     color = MaterialTheme.colorScheme.primary
                 )
+
                 Switch(
-                    enabled = XposedChecker.isEnabled(),
                     checked = isSwitchOn.value,
                     onCheckedChange = {
                         PrefsUtils.toggleHookState()
@@ -101,13 +115,15 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.padding(10.dp)
                 )
             }
+        } else {
             Text(
-                text = "Counter: $counter",
-                fontSize = 40.sp,
+                text = "CaptureSposed is not enabled. Please enable it in the LSPosed Manager, reboot your device, and try again.",
+                fontSize = 20.sp,
                 textAlign = TextAlign.Center,
-                modifier = Modifier.padding(50.dp),
-                color = MaterialTheme.colorScheme.secondary
+                color = MaterialTheme.colorScheme.tertiary,
+                modifier = Modifier.padding(10.dp)
             )
         }
+
     }
 }

--- a/app/src/main/java/com/keshav/capturesposed/MainActivity.kt
+++ b/app/src/main/java/com/keshav/capturesposed/MainActivity.kt
@@ -117,7 +117,7 @@ class MainActivity : ComponentActivity() {
             }
         } else {
             Text(
-                text = "CaptureSposed is not enabled. Please enable it in the LSPosed Manager, reboot your device, and try again.",
+                text = getString(R.string.module_disabled),
                 fontSize = 20.sp,
                 textAlign = TextAlign.Center,
                 color = MaterialTheme.colorScheme.tertiary,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="xposed_name">CaptureSposed</string>
     <string name="xposed_description">Add support for suppressing the Screenshot Detection API introduced in Android 14!</string>
     <string name="tile_label">Block Screenshot Detection</string>
+    <string name="module_disabled">CaptureSposed is not enabled. Please enable it in the LSPosed Manager, reboot your device, and try again.</string>
 </resources>


### PR DESCRIPTION
This PR introduces changes to `MainActivity.kt`. Created a new `Composable` function `SwitchOrText` to add a conditional statement that determines whether to display a switch or a message based on the status of `XposedChecke.isEnabled()`

#### App when `XposedChecke.isEnabled()` returns `False`
![Screenshot_20240521_123156](https://github.com/99keshav99/CaptureSposed/assets/47789950/4e0255d4-52a1-45db-9d3a-11b11cd6c8d3)

#### App when `XposedChecke.isEnabled()` returns `True`
![Screenshot_20240521_130449](https://github.com/99keshav99/CaptureSposed/assets/47789950/713181c8-9851-469f-83fe-5a00ba0f9930)
