### PR TITLE
Migrate to Building for SDK 35 (Android 15) and Implement Edge-to-Edge App Support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,13 +5,13 @@ plugins {
 
 android {
     namespace = "com.keshav.capturesposed"
-    compileSdk = 34
-    buildToolsVersion = "34.0.0"
+    compileSdk = 35
+    buildToolsVersion = "35.0.0"
 
     defaultConfig {
         applicationId = "com.keshav.capturesposed"
         minSdk = 34
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 6
         versionName = "1.0.5"
 

--- a/app/src/main/java/com/keshav/capturesposed/MainActivity.kt
+++ b/app/src/main/java/com/keshav/capturesposed/MainActivity.kt
@@ -4,12 +4,16 @@ import android.app.Activity.ScreenCaptureCallback
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -47,6 +51,7 @@ class MainActivity : ComponentActivity() {
     private lateinit var isSwitchOn: MutableState<Boolean>
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         setTheme(R.style.Theme_APP)
         super.onCreate(savedInstanceState)
         counter.intValue = savedInstanceState?.getInt("counter") ?: 0
@@ -108,6 +113,7 @@ class MainActivity : ComponentActivity() {
             modifier = modifier
                 .nestedScroll(scrollBehavior.nestedScrollConnection)
                 .fillMaxSize()
+                .windowInsetsPadding(WindowInsets.displayCutout)
         ) { p ->
             Column(
                 modifier = modifier

--- a/app/src/main/java/com/keshav/capturesposed/MainActivity.kt
+++ b/app/src/main/java/com/keshav/capturesposed/MainActivity.kt
@@ -68,7 +68,7 @@ class MainActivity : ComponentActivity() {
                 Surface(
                     color = MaterialTheme.colorScheme.surfaceContainer
                 ) {
-                    AppUI(counter.intValue)
+                    AppUI()
                 }
             }
         }
@@ -95,7 +95,7 @@ class MainActivity : ComponentActivity() {
 
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
-    fun AppUI(counter: Int, modifier: Modifier = Modifier) {
+    fun AppUI(modifier: Modifier = Modifier) {
         val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
 
         Scaffold(


### PR DESCRIPTION
This pull request migrates CaptureSposed to building for SDK 35 and updates the app's user interface to properly support Android 15's mandatory support for edge-to-edge app displays.