### PR TITLE
Update from JDK 17 to 21 to fix F-Droid Build Failure

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,12 +37,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 
     kotlin {
-        jvmToolchain(17)
+        jvmToolchain(21)
     }
 
     packaging {


### PR DESCRIPTION
This change updates the JDK used for building CaptureSposed from 17 to 21 in order to fix issue #82.